### PR TITLE
Update init.rb to be compatible with Redmine 5.x

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'redmine'
 ::Rails.logger.info 'Redmine LaTeX MathJax Macro'
-require File.dirname(__FILE__) + '/lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook'
+require File.expand_path('../lib/redmine_latex_mathjax/hooks/view_layouts_base_html_head_hook', __FILE__)
 
 Redmine::Plugin.register :redmine_latex_mathjax do
   name 'Redmine LaTeX MathJax Macro'


### PR DESCRIPTION
This takes the single change from #3 required to make this plugin work with Redmine 5.x (tested with 5.0.9) without any of the additional modifications that #3 would introduce.

Also fixes #2 